### PR TITLE
adapted to python3

### DIFF
--- a/eval/inception/score.py
+++ b/eval/inception/score.py
@@ -151,7 +151,7 @@ if __name__ == '__main__':
 
   print('p(y)')
   for i in xrange(10):
-    n = len(filter(lambda x: x == i, labels))
+    n = len([x for x in labels if x == i])
     print('{}: {}'.format(i, n / float(args.n)))
 
   # Save labels


### PR DESCRIPTION
Python 3 will raise "TypeError: object of type 'filter' has no len()" when a len is called on a filter object. A quick workaround to that would be instead of having len(filter), having len(list(filter)). This practically defeats the purpose of using a filter and in my opinion is less pythonic than using a list comprehension, therefore I'm suggesting this change instead of the more straight len(list).