### PR TITLE
Explicit and restrict the conversion to float32.

### DIFF
--- a/eval/inception/score.py
+++ b/eval/inception/score.py
@@ -51,8 +51,9 @@ def inception_score(
         fs, _x = wavread(audio_fp)
         if fs != 16000:
           raise Exception('Invalid sample rate ({})'.format(fs))
-        _x = _x.astype(np.float32)
-        _x /= 32767.
+        if _x.dtype==np.int16:
+            _x = _x.astype(np.float32)
+            _x /= 32767.
 
       if _x.ndim != 1:
         raise Exception('Invalid shape ({})'.format(_x.shape))


### PR DESCRIPTION
This conversion is not needed if the wavfiles are saved with 32-bit floating-point, which is the default for scipy.io.wavfile.write of files with dtype float32. Applying this conversion to those files destroys them giving really low inception scores.