### PR TITLE
prevent args.txt from being overwritten by preview

### DIFF
--- a/train_wavegan.py
+++ b/train_wavegan.py
@@ -626,7 +626,7 @@ if __name__ == '__main__':
     os.makedirs(args.train_dir)
 
   # Save args
-  with open(os.path.join(args.train_dir, 'args.txt'), 'w') as f:
+  with open(os.path.join(args.train_dir, 'args_%s.txt' % args.mode), 'w') as f:
     f.write('\n'.join([str(k) + ',' + str(v) for k, v in sorted(vars(args).items(), key=lambda x: x[0])]))
 
   # Make model kwarg dicts


### PR DESCRIPTION
Note: args.txt will still be overwritten if restarting the training session.

I'll submit a second proposal with a more complete fix